### PR TITLE
fix(proxyup): Set docker-compose project name on proxyup

### DIFF
--- a/scripts/craft-3/proxyup.bash
+++ b/scripts/craft-3/proxyup.bash
@@ -11,7 +11,7 @@ echo
 ok=false
 
 if [ "$IDENT_DOCKER" = true ]; then
-  cd / && curl https://lab.fork.de/snippets/3/raw | docker-compose -f - up -d || docker start nginx-proxy
+  cd / && curl https://lab.fork.de/snippets/3/raw | docker-compose -p default -f - up -d || docker start nginx-proxy
 
   echo
   echo "$I18N_SUCCESS Done"


### PR DESCRIPTION
Fixes the following error from occuring:

```
Error response from daemon: no such image: _nginx-proxy: invalid reference format
```